### PR TITLE
Add Chinese conversation practice webapp

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # codex-test
 Testing out openai codex
+
+## Chinese Conversation Practice Webapp
+
+A single-page webapp (`index.html`) lets you practice Chinese conversation using the OpenAI API. Enter your API key and a scenario, click **Go**, and converse with your AI teacher 小王.
+
+### Usage
+1. Open `index.html` in your browser.
+2. Provide your OpenAI API key and a scenario.
+3. Click **Go** to begin. The teacher speaks first. After each response, click **Record** to answer.
+4. Click **Stop** at any time to end the conversation.
+
+All requests are made directly from the browser, so your API key is never sent anywhere except the OpenAI API.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Chinese Conversation Practice</title>
+<style>
+body { font-family: Arial, sans-serif; margin: 20px; }
+#transcript { border: 1px solid #ccc; padding: 10px; height: 200px; width: 100%; overflow-y: auto; white-space: pre-wrap; }
+#recordButton { margin-left: 10px; }
+</style>
+</head>
+<body>
+<h1>Chinese Conversation Practice</h1>
+<label>OpenAI API Key: <input type="password" id="apiKey"></label><br><br>
+<textarea id="scenario" rows="3" cols="60" placeholder="Describe your practice scenario here..."></textarea><br>
+<button id="startStop">Go</button>
+<button id="recordButton" disabled>Record</button>
+<div id="transcript"></div>
+<audio id="ttsAudio"></audio>
+<script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,149 @@
+let conversation = [];
+let mediaRecorder;
+let audioChunks = [];
+let running = false;
+let recording = false;
+const systemPrompt = `You are a friendly Chinese teacher named 小王. Speak slowly. Hold conversational practice with the learner:\n- Speak mostly Mandarin Chinese, sprinkling English only when necessary for comprehension.\n- Subtly correct grammar, vocabulary and pronunciation after each learner utterance.\n- Steer conversation toward previously learned grammar and vocab.\n- If the learner says "word是什么？", give the English meaning.\n- If learner asks about a grammar structure, explain briefly in English followed by a Chinese example.\n- Begin now with the scenario the learner provided.`;
+
+const apiKeyInput = document.getElementById('apiKey');
+const scenarioInput = document.getElementById('scenario');
+const startStopBtn = document.getElementById('startStop');
+const recordBtn = document.getElementById('recordButton');
+const transcriptDiv = document.getElementById('transcript');
+const ttsAudio = document.getElementById('ttsAudio');
+
+startStopBtn.addEventListener('click', () => {
+  if (!running) {
+    startConversation();
+  } else {
+    stopConversation();
+  }
+});
+
+recordBtn.addEventListener('click', () => {
+  if (!recording) {
+    startRecording();
+  } else {
+    stopRecording();
+  }
+});
+
+ttsAudio.addEventListener('ended', () => {
+  if (running) {
+    recordBtn.disabled = false;
+  }
+});
+
+async function startConversation() {
+  const apiKey = apiKeyInput.value.trim();
+  if (!apiKey) {
+    alert('Please enter your OpenAI API key.');
+    return;
+  }
+  running = true;
+  startStopBtn.textContent = 'Stop';
+  transcriptDiv.textContent = '';
+  conversation = [
+    { role: 'system', content: systemPrompt },
+    { role: 'user', content: scenarioInput.value.trim() }
+  ];
+  console.log('Starting conversation');
+  await getAssistantResponse(apiKey);
+}
+
+function stopConversation() {
+  running = false;
+  if (recording) {
+    mediaRecorder.stop();
+  }
+  startStopBtn.textContent = 'Go';
+  recordBtn.disabled = true;
+  console.log('Conversation stopped');
+}
+
+async function startRecording() {
+  if (!running) return;
+  recordBtn.textContent = 'Stop Recording';
+  recordBtn.disabled = false;
+  recording = true;
+  audioChunks = [];
+  const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+  mediaRecorder = new MediaRecorder(stream);
+  mediaRecorder.start();
+  mediaRecorder.addEventListener('dataavailable', event => {
+    audioChunks.push(event.data);
+  });
+  mediaRecorder.addEventListener('stop', async () => {
+    const audioBlob = new Blob(audioChunks, { type: 'audio/webm' });
+    console.log('Recording stopped, sending to OpenAI');
+    await sendUserAudio(audioBlob);
+    stream.getTracks().forEach(t => t.stop());
+  });
+}
+
+function stopRecording() {
+  if (!recording) return;
+  recordBtn.textContent = 'Record';
+  recording = false;
+  mediaRecorder.stop();
+  recordBtn.disabled = true;
+}
+
+async function sendUserAudio(blob) {
+  const apiKey = apiKeyInput.value.trim();
+  const formData = new FormData();
+  formData.append('file', blob, 'speech.webm');
+  formData.append('model', 'gpt-4o-transcribe');
+
+  const sttResponse = await fetch('https://api.openai.com/v1/audio/transcriptions', {
+    method: 'POST',
+    headers: { 'Authorization': `Bearer ${apiKey}` },
+    body: formData
+  });
+  const sttData = await sttResponse.json();
+  const userText = sttData.text;
+  conversation.push({ role: 'user', content: userText });
+  transcriptDiv.textContent += `\nYou: ${userText}`;
+  console.log('User said:', userText);
+  await getAssistantResponse(apiKey);
+}
+
+async function getAssistantResponse(apiKey) {
+  const chatResponse = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${apiKey}`
+    },
+    body: JSON.stringify({
+      model: 'gpt-4o',
+      messages: conversation
+    })
+  });
+  const chatData = await chatResponse.json();
+  const assistantText = chatData.choices[0].message.content;
+  conversation.push({ role: 'assistant', content: assistantText });
+  transcriptDiv.textContent += `\nTeacher: ${assistantText}`;
+  console.log('Assistant:', assistantText);
+  await speakAssistantText(apiKey, assistantText);
+}
+
+async function speakAssistantText(apiKey, text) {
+  const ttsResponse = await fetch('https://api.openai.com/v1/audio/speech', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${apiKey}`
+    },
+    body: JSON.stringify({
+      model: 'gpt-4o-mini-tts',
+      input: text,
+      voice: 'nova'
+    })
+  });
+  const ttsBlob = await ttsResponse.blob();
+  const url = URL.createObjectURL(ttsBlob);
+  ttsAudio.src = url;
+  await ttsAudio.play();
+  console.log('Playing assistant audio');
+}


### PR DESCRIPTION
## Summary
- create single page webapp for practicing Chinese conversation
- handle speech to text, chat completion, and text to speech via OpenAI API
- update README with usage instructions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684a827076ac8321bf7714bbaa59d493