### PR TITLE
Fix repeat button visibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,6 +32,18 @@ body { font-family: Arial, sans-serif; margin: 20px; }
   font-size: 12px;
   margin-top: 10px;
 }
+#repeatButton {
+  /* repeat button style */
+  width: 80px;
+  height: 80px;
+  border-radius: 50%;
+  border: none;
+  background-color: #2196F3;
+  color: white;
+  font-size: 12px;
+  margin-top: 10px;
+  margin-right: 10px;
+}
 #talkButton.holding {
   /* button pressed state */
   background-color: #45A049;
@@ -69,10 +81,9 @@ body { font-family: Arial, sans-serif; margin: 20px; }
 <button id="startStop">Go</button>
 
 <!-- conversation transcript -->
-<div id="transcript">
-  <!-- replay last teacher reply -->
-  <button id="repeatButton" disabled>请再说一次</button>
-</div>
+<div id="transcript"></div>
+<!-- replay last teacher reply -->
+<button id="repeatButton" disabled>请再说一次</button>
 <!-- hold to record your voice -->
 <button id="talkButton" disabled>说话时按住 (Press and hold while speaking)</button>
 

--- a/script.js
+++ b/script.js
@@ -94,6 +94,7 @@ ttsAudio.addEventListener('ended', () => {
   if (running) {
     talkBtn.disabled = false;
     talkBtn.textContent = '说话时按住 (Press and hold while speaking)';
+    repeatBtn.disabled = false;
   }
 });
 
@@ -107,6 +108,7 @@ async function startConversation() {
   running = true;
   startStopBtn.textContent = 'Stop';
   transcriptDiv.textContent = '';
+  repeatBtn.disabled = true;
   talkBtn.textContent = '老师正在讲话 (Teacher is speaking)...';
   talkBtn.disabled = true;
   conversation = [
@@ -210,6 +212,7 @@ async function getAssistantResponse(apiKey) {
 async function speakAssistantText(apiKey, text) {
   talkBtn.textContent = '老师正在讲话 (Teacher is speaking)...';
   talkBtn.disabled = true;
+  repeatBtn.disabled = true;
   const ttsResponse = await fetch('https://api.openai.com/v1/audio/speech', {
     method: 'POST',
     headers: {


### PR DESCRIPTION
## Summary
- show the "再说一次" button below the transcript
- style it as a circular button
- disable/enable the repeat button when teacher speech plays

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_684a96249f648321b8b7f377b1b1cadc